### PR TITLE
Relayed tx v1 builder exported

### DIFF
--- a/builders/interface.go
+++ b/builders/interface.go
@@ -55,8 +55,8 @@ type Signer interface {
 }
 
 type RelayedTxV1Builder interface {
-	SetInnerTransaction(tx *transaction.FrontendTransaction) *relayedTxV1Builder
-	SetRelayerAccount(account *data.Account) *relayedTxV1Builder
-	SetNetworkConfig(config *data.NetworkConfig) *relayedTxV1Builder
+	SetInnerTransaction(tx *transaction.FrontendTransaction) RelayedTxV1Builder
+	SetRelayerAccount(account *data.Account) RelayedTxV1Builder
+	SetNetworkConfig(config *data.NetworkConfig) RelayedTxV1Builder
 	Build() (*transaction.FrontendTransaction, error)
 }

--- a/builders/interface.go
+++ b/builders/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
 	crypto "github.com/multiversx/mx-chain-crypto-go"
+
 	"github.com/multiversx/mx-sdk-go/core"
 	"github.com/multiversx/mx-sdk-go/data"
 )
@@ -51,4 +52,11 @@ type Signer interface {
 	SignByteSlice(msg []byte, privateKey crypto.PrivateKey) ([]byte, error)
 	VerifyByteSlice(msg []byte, publicKey crypto.PublicKey, sig []byte) error
 	IsInterfaceNil() bool
+}
+
+type RelayedTxV1Builder interface {
+	SetInnerTransaction(tx *transaction.FrontendTransaction) *relayedTxV1Builder
+	SetRelayerAccount(account *data.Account) *relayedTxV1Builder
+	SetNetworkConfig(config *data.NetworkConfig) *relayedTxV1Builder
+	Build() (*transaction.FrontendTransaction, error)
 }

--- a/builders/relayedTxV1Builder.go
+++ b/builders/relayedTxV1Builder.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+
 	"github.com/multiversx/mx-sdk-go/core"
 	"github.com/multiversx/mx-sdk-go/data"
 )
@@ -17,7 +18,7 @@ type relayedTxV1Builder struct {
 }
 
 // NewRelayedTxV1Builder creates a new relayed transaction v1 builder
-func NewRelayedTxV1Builder() *relayedTxV1Builder {
+func NewRelayedTxV1Builder() RelayedTxV1Builder {
 	return &relayedTxV1Builder{
 		innerTransaction: nil,
 		relayerAccount:   nil,
@@ -26,21 +27,21 @@ func NewRelayedTxV1Builder() *relayedTxV1Builder {
 }
 
 // SetInnerTransaction sets the inner transaction to be relayed
-func (rtb *relayedTxV1Builder) SetInnerTransaction(tx *transaction.FrontendTransaction) *relayedTxV1Builder {
+func (rtb *relayedTxV1Builder) SetInnerTransaction(tx *transaction.FrontendTransaction) RelayedTxV1Builder {
 	rtb.innerTransaction = tx
 
 	return rtb
 }
 
 // SetRelayerAccount sets the relayer account
-func (rtb *relayedTxV1Builder) SetRelayerAccount(account *data.Account) *relayedTxV1Builder {
+func (rtb *relayedTxV1Builder) SetRelayerAccount(account *data.Account) RelayedTxV1Builder {
 	rtb.relayerAccount = account
 
 	return rtb
 }
 
 // SetNetworkConfig sets the network config
-func (rtb *relayedTxV1Builder) SetNetworkConfig(config *data.NetworkConfig) *relayedTxV1Builder {
+func (rtb *relayedTxV1Builder) SetNetworkConfig(config *data.NetworkConfig) RelayedTxV1Builder {
 	rtb.networkConfig = config
 
 	return rtb


### PR DESCRIPTION
I know this one breaks a bit the multiversx code-style, but outside the sdk it is very hard to implement builder patterns. I firmly believe this is a much more better approach to the builder pattern and should be changed across all mvx components.