### PR TITLE
Fix relayV1Builder

### DIFF
--- a/builders/relayedTxV1Builder.go
+++ b/builders/relayedTxV1Builder.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+
 	"github.com/multiversx/mx-sdk-go/core"
 	"github.com/multiversx/mx-sdk-go/data"
 )
@@ -70,14 +71,8 @@ func (rtb *relayedTxV1Builder) Build() (*transaction.FrontendTransaction, error)
 	payload := []byte("relayedTx@" + innerTxHex)
 	gasLimit := rtb.networkConfig.MinGasLimit + rtb.networkConfig.GasPerDataByte*uint64(len(payload)) + rtb.innerTransaction.GasLimit
 
-	innerTxValue, ok := big.NewInt(0).SetString(rtb.innerTransaction.Value, 10)
-	if !ok {
-		return nil, ErrInvalidValue
-	}
-
 	relayedTx := &transaction.FrontendTransaction{
 		Nonce:    rtb.relayerAccount.Nonce,
-		Value:    innerTxValue.String(),
 		Receiver: rtb.innerTransaction.Sender,
 		Sender:   rtb.relayerAccount.Address,
 		GasPrice: rtb.innerTransaction.GasPrice,


### PR DESCRIPTION
As it is right now, the value from the inner transaction is passed to the relayer as well. When using this functionality the relayer is expected to pay only the computation fees. The current behaviour is that beside the computation fees, the relayer also pays the value of the transaction for the sender instead.

