### PR TITLE
Added value checker inside relayed transactions v2.

### DIFF
--- a/builders/errors.go
+++ b/builders/errors.go
@@ -41,6 +41,9 @@ var ErrInvalidGasLimitNeededForInnerTransaction = errors.New("invalid gas limit 
 // ErrGasLimitForInnerTransactionV2ShouldBeZero signals that the gas limit for the inner transaction should be zero
 var ErrGasLimitForInnerTransactionV2ShouldBeZero = errors.New("gas limit of the inner transaction should be 0")
 
+// ErrInvalidValueForInnerTransaction signals that the inner transaction value for relayed tx v2 should be 0
+var ErrInvalidValueForInnerTransaction = errors.New("value of the inner transaction should be 0")
+
 // ErrMissingGuardianOption signals that the guardian flag is missing in the transaction option field
 var ErrMissingGuardianOption = errors.New("guardian flag is missing in the option field")
 

--- a/builders/relayedTxV1Builder.go
+++ b/builders/relayedTxV1Builder.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+
 	"github.com/multiversx/mx-sdk-go/core"
 	"github.com/multiversx/mx-sdk-go/data"
 )
@@ -70,14 +71,8 @@ func (rtb *relayedTxV1Builder) Build() (*transaction.FrontendTransaction, error)
 	payload := []byte("relayedTx@" + innerTxHex)
 	gasLimit := rtb.networkConfig.MinGasLimit + rtb.networkConfig.GasPerDataByte*uint64(len(payload)) + rtb.innerTransaction.GasLimit
 
-	innerTxValue, ok := big.NewInt(0).SetString(rtb.innerTransaction.Value, 10)
-	if !ok {
-		return nil, ErrInvalidValue
-	}
-
 	relayedTx := &transaction.FrontendTransaction{
 		Nonce:    rtb.relayerAccount.Nonce,
-		Value:    innerTxValue.String(),
 		Receiver: rtb.innerTransaction.Sender,
 		Sender:   rtb.relayerAccount.Address,
 		GasPrice: rtb.innerTransaction.GasPrice,

--- a/builders/relayedTxV2Builder.go
+++ b/builders/relayedTxV2Builder.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/data/transaction"
+
 	"github.com/multiversx/mx-sdk-go/core"
 	"github.com/multiversx/mx-sdk-go/data"
 )
@@ -75,6 +76,9 @@ func (rtb *relayedTxV2Builder) Build() (*transaction.FrontendTransaction, error)
 	if rtb.innerTransaction.GasLimit != 0 {
 		return nil, ErrGasLimitForInnerTransactionV2ShouldBeZero
 	}
+	if rtb.innerTransaction.Value != "0" {
+		return nil, ErrInvalidValueForInnerTransaction
+	}
 
 	innerTxHex, err := prepareInnerTxForRelayV2(rtb.innerTransaction)
 	if err != nil {
@@ -86,7 +90,7 @@ func (rtb *relayedTxV2Builder) Build() (*transaction.FrontendTransaction, error)
 
 	relayedTx := &transaction.FrontendTransaction{
 		Nonce:    rtb.relayerAccount.Nonce,
-		Value:    "0",
+		Value:    rtb.innerTransaction.Value,
 		Receiver: rtb.innerTransaction.Sender,
 		Sender:   rtb.relayerAccount.Address,
 		GasPrice: rtb.innerTransaction.GasPrice,


### PR DESCRIPTION
Because of the missing check. One could pass in a signed transaction with a value different to 0. The builder will overwrite the `value` field anyway and thus making the signature invalid.